### PR TITLE
Fix PIDLoop Kd

### DIFF
--- a/src/kOS.Safe/Encapsulation/PIDLoop.cs
+++ b/src/kOS.Safe/Encapsulation/PIDLoop.cs
@@ -156,7 +156,7 @@ namespace kOS.Safe.Encapsulation
                     ChangeRate = (input - Input) / dt;
                     if (Kd != 0)
                     {
-                        dTerm = ChangeRate * Kd;
+                        dTerm = -ChangeRate * Kd;
                     }
                 }
             }


### PR DESCRIPTION
PIDLoop.cs
- Change the dterm to use a negative value of the ChangeRate to make
  positive signed dTerms work in positive proportion to error.
