### PR TITLE
Fix quicksave

### DIFF
--- a/src/kOS/Binding/BindingsUniverse.cs
+++ b/src/kOS/Binding/BindingsUniverse.cs
@@ -12,52 +12,9 @@ namespace kOS.Binding
     [Binding("ksp")]
     public class BindingTimeWarp : Binding
     {
-        private static readonly IList<string> reservedSaveNames = new List<string> { "persistence", "quicksave" };
-
         public override void AddTo(SharedObjects shared)
         {
             shared.BindingMgr.AddGetter("KUNIVERSE", () => new KUniverseValue(shared));
-            shared.BindingMgr.AddGetter("QUICKSAVE", () =>
-            {
-                if (!HighLogic.CurrentGame.Parameters.Flight.CanQuickSave) return false;
-                QuickSaveLoad.QuickSave();
-                return true;
-            });
-
-            shared.BindingMgr.AddGetter("QUICKLOAD", () =>
-                {
-                    if (!HighLogic.CurrentGame.Parameters.Flight.CanQuickLoad) return false;
-                    try
-                    {
-                        GamePersistence.LoadGame("quicksave", HighLogic.SaveFolder, true, false);
-                    }
-                    catch (Exception ex)
-                    {
-                        SafeHouse.Logger.Log(ex.Message);
-                        return false;
-                    }
-                    return true;
-                });
-
-            shared.BindingMgr.AddSetter("SAVETO", val =>
-                {
-                    if (reservedSaveNames.Contains(val.ToString().ToLower())) return;
-
-                    Game game = HighLogic.CurrentGame.Updated();
-                    game.startScene = GameScenes.FLIGHT;
-                    GamePersistence.SaveGame(game, val.ToString(), HighLogic.SaveFolder, SaveMode.OVERWRITE);
-                });
-
-            shared.BindingMgr.AddSetter("LOADFROM", val =>
-                {
-                    if (reservedSaveNames.Contains(val.ToString().ToLower())) return;
-
-                    var game = GamePersistence.LoadGame(val.ToString(), HighLogic.SaveFolder, true, false);
-                    if (game == null) return;
-                    if (game.flightState == null) return;
-                    if (!game.compatible) return;
-                    FlightDriver.StartAndFocusVessel(game, game.flightState.activeVesselIdx);
-                });
 
             shared.BindingMgr.AddGetter("WARPMODE", () =>
                 {

--- a/src/kOS/Suffixed/KUniverseValue.cs
+++ b/src/kOS/Suffixed/KUniverseValue.cs
@@ -3,6 +3,9 @@ using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Utilities;
+using System;
+using System.IO;
+using System.Collections.Generic;
 
 namespace kOS.Suffixed
 {
@@ -25,6 +28,11 @@ namespace kOS.Suffixed
             AddSuffix("REVERTTOLAUNCH", new NoArgsVoidSuffix(RevertToLaunch));
             AddSuffix("REVERTTOEDITOR", new NoArgsVoidSuffix(RevertToEditor));
             AddSuffix("REVERTTO", new OneArgsSuffix<StringValue>(RevertTo));
+            AddSuffix("QUICKSAVE", new NoArgsVoidSuffix(QuickSave));
+            AddSuffix("QUICKLOAD", new NoArgsVoidSuffix(QuickLoad));
+            AddSuffix("QUICKSAVETO", new OneArgsSuffix<StringValue>(QuickSaveTo));
+            AddSuffix("QUICKLOADFROM", new OneArgsSuffix<StringValue>(QuickLoadFrom));
+            AddSuffix("QUICKSAVELIST", new NoArgsSuffix<ListValue>(GetQuicksaveList));
             AddSuffix("ORIGINEDITOR", new Suffix<StringValue>(OriginatingEditor));
             AddSuffix("DEFAULTLOADDISTANCE", new Suffix<LoadDistanceValue>(() => new LoadDistanceValue(PhysicsGlobals.Instance.VesselRangesDefault)));
             AddSuffix("ACTIVEVESSEL", new SetSuffix<VesselTarget>(() => new VesselTarget(FlightGlobals.ActiveVessel, shared), SetActiveVessel));
@@ -127,6 +135,114 @@ namespace kOS.Suffixed
         public void DebugLog(StringValue message)
         {
             SafeHouse.Logger.Log("(KUNIVERSE:DEBUGLOG) " + message);
+        }
+
+        public void QuickSave()
+        {
+            if (HighLogic.CurrentGame.Parameters.Flight.CanQuickSave)
+            {
+                QuickSaveLoad.QuickSave();
+            }
+            else throw new KOSException("KSP prevents using quicksave currently.");
+        }
+
+        public void QuickSaveTo(StringValue name)
+        {
+            QuickSaveTo(name.ToString());
+        }
+
+        public void QuickSaveTo(string name)
+        {
+            if (name.EndsWith(".sfs"))
+            {
+                name = name.Substring(0, name.Length - 4);
+            }
+            var reserved = new List<string>() { "persistent", "quicksave", "kos-backup-quicksave" };
+            if (reserved.Contains(name))
+            {
+                throw new KOSException("Cannot save to " + name + " because it is a reserved name.");
+            }
+            SaveGame(name);
+        }
+
+        private void SaveGame(string name)
+        {
+            if (HighLogic.CurrentGame.Parameters.Flight.CanQuickSave)
+            {
+                GamePersistence.SaveGame(name, HighLogic.SaveFolder, SaveMode.OVERWRITE);
+            }
+            else throw new KOSException("KSP prevents using quicksave currently.");
+        }
+
+        public void QuickLoad()
+        {
+            LoadGame("quicksave");
+        }
+
+        public void QuickLoadFrom(StringValue name)
+        {
+            LoadGame(name.ToString());
+        }
+
+        private void LoadGame(string name)
+        {
+            if (name.EndsWith(".sfs"))
+            {
+                name = name.Substring(0, name.Length - 4);
+            }
+            if (HighLogic.CurrentGame.Parameters.Flight.CanQuickLoad)
+            {
+                string filename = name + ".sfs";
+                string path = KSPUtil.GetOrCreatePath("saves/" + HighLogic.SaveFolder);
+                if (!File.Exists(Path.Combine(path, filename)))
+                {
+                    throw new KOSException("Error loading the quicksave file, the save file does not exist.");
+                }
+                try
+                {
+                    SaveGame("kos-backup-quicksave");
+                    var game = GamePersistence.LoadGame(name, HighLogic.SaveFolder, true, false);
+                    if (game.flightState != null)
+                    {
+                        if (game.compatible)
+                        {
+                            GamePersistence.UpdateScenarioModules(game);
+                            if (game.startScene != GameScenes.FLIGHT)
+                            {
+                                if (KSPUtil.CheckVersion(game.file_version_major, game.file_version_minor, game.file_version_revision, 0, 24, 0) != VersionCompareResult.INCOMPATIBLE_TOO_EARLY)
+                                {
+                                    GamePersistence.SaveGame(game, name, HighLogic.SaveFolder, SaveMode.OVERWRITE);
+                                    HighLogic.LoadScene(GameScenes.SPACECENTER);
+                                    return;
+                                }
+                            }
+                            FlightDriver.StartAndFocusVessel(game, game.flightState.activeVesselIdx);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    SafeHouse.Logger.Log(ex.Message);
+                    throw new KOSException("Error loading the quicksave file");
+                }
+            }
+            else throw new KOSException("KSP prevents using quickload currently.");
+        }
+
+        private ListValue GetQuicksaveList()
+        {
+            var ret = new ListValue();
+            string path = KSPUtil.GetOrCreatePath("saves/" + HighLogic.SaveFolder);
+            var files = Directory.GetFiles(path, "*.sfs");
+            foreach (var file in files)
+            {
+                string name = Path.GetFileNameWithoutExtension(file);
+                if (!name.Equals("persistent"))
+                {
+                    ret.Add(new StringValue(name));
+                }
+            }
+            return ret;
         }
     }
 }


### PR DESCRIPTION
Fixes #1372

Gets quicksave and quickload to work again.  The functionality has been moved to KUNIVERSE (my catch-all solution to reducing binding inflation).  I implemented it such that you can both save and load the default quicksave (named "quicksave") as well as save to and from a specified file.  You can also get a list of existing saves.

Features:
- [x] Save default quicksave
- [x] Load default quicksave
- [x] Save an arbitrary quicksave file
- [x] Load an arbitrary quicksave file
- [x] List available quicksave files from kuniverse
- [ ] List available quicksave files using `list quicksaves in lst.` syntax
- [ ] Print available quicksave files using `list quicksaves.` syntax.
- [ ] Documentation
